### PR TITLE
provider.py: change argument name from `config` to `state`

### DIFF
--- a/auth_gitlab/provider.py
+++ b/auth_gitlab/provider.py
@@ -26,7 +26,7 @@ class GitLabOAuth2Provider(OAuth2Provider):
     def get_refresh_token_url(self):
         return ACCESS_TOKEN_URL
 
-    def build_config(self, config):
+    def build_config(self, state):
         return {}
 
     def build_identity(self, state):


### PR DESCRIPTION
This fixes the provider wrt. the following Sentry commit:

https://github.com/getsentry/sentry/commit/326315f938c6ddff632db34416821f426eb6acec#diff-e0494c56201878812ba2d58e03a3e6310b0da0b3ed3f5c8ee6c0c9fa243d54aaR858

...which changed the invocation to use a kwarg, causing a mismatch between sentry and sentry-auth-gitlab.