### PR TITLE
provider.py: implement missing abstract methods

### DIFF
--- a/auth_gitlab/provider.py
+++ b/auth_gitlab/provider.py
@@ -38,3 +38,9 @@ class GitLabOAuth2Provider(OAuth2Provider):
             'name': user_data['name'],
             'data': self.get_oauth_data(data),
         }
+
+    def get_client_id():
+        return CLIENT_ID
+
+    def get_client_secret():
+        return CLIENT_SECRET


### PR DESCRIPTION
This commit trivially implements `get_client_id()` and `get_client_secret()`.

This prevents Sentry's `web` container from dying w/ HTTP 500s while serving requests with the following error:

`TypeError: Can't instantiate abstract class GitLabOAuth2Provider with abstract methods get_client_id, get_client_secret`