### PR TITLE
fix: update parameter name for compatibility with Sentry

### DIFF
--- a/auth_gitlab/views.py
+++ b/auth_gitlab/views.py
@@ -3,8 +3,8 @@ from sentry.auth.view import AuthView
 from .client import GitLabClient
 
 class FetchUser(AuthView):
-    def handle(self, request, pipeline):
-        with GitLabClient(pipeline.fetch_state('data')['access_token']) as client:
+    def handle(self, request, helper):
+        with GitLabClient(helper.fetch_state('data')['access_token']) as client:
             user = client.get_user()
-            pipeline.bind_state('user', user)
-            return pipeline.next_step()
+            helper.bind_state('user', user)
+            return helper.next_step()


### PR DESCRIPTION
Renamed the 'pipeline' parameter to 'helper' in the FetchUser class to align with recent changes in Sentry's API. This ensures proper functionality with the latest versions.